### PR TITLE
fix(DM_phase): deprecated np.int -> int

### DIFF
--- a/DM_phase/__init__.py
+++ b/DM_phase/__init__.py
@@ -868,8 +868,8 @@ def _check_window(profile, window):
         window += np.abs(peak_value - peak) / 2
         peak_value = (peak_value + peak) / 2
 
-    start = np.int(peak_value - np.round(1.25 * window))
-    end = np.int(peak_value + np.round(1.25 * window))
+    start = int(peak_value - np.round(1.25 * window))
+    end = int(peak_value + np.round(1.25 * window))
 
     if start < 0:
         start = 0


### PR DESCRIPTION
```
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```